### PR TITLE
Fix calculating button absolute path length

### DIFF
--- a/source/keyboard.test.ts
+++ b/source/keyboard.test.ts
@@ -130,26 +130,24 @@ test('hints too long callback data', async t => {
 	const ten = '0123456789'
 
 	const k = new Keyboard<unknown>()
-	k.add(false, {text: 'bla', relativePath: ten + ten + ten})
+	k.add(false, {text: 'bla', relativePath: ten + ten + ten + ten + ten})
 
 	await t.throwsAsync(
-		async () => {
-			await k.render(undefined, `/${ten}${ten}/${ten}${ten}${ten}/`)
-		},
+		// This would render to /some/long/base/ + 5*ten which is longer than 64 chars
+		async () => k.render(undefined, '/some/long/base/'),
 		{message: /callback_data only supports 1-64 bytes/},
 	)
 })
 
 test('hints too long cyrillic callback data', async t => {
+	// This is 48 characters but due to unicode its 2*48 -> more than 64
 	const relativePath = 'очень длинный абсолютный путь больше 32 символов'
 
 	const k = new Keyboard<unknown>()
-	k.add(false, {text: 'bla', relativePath: `/${relativePath}/`})
+	k.add(false, {text: 'bla', relativePath})
 
 	await t.throwsAsync(
-		async () => {
-			await k.render(undefined, `/${relativePath}/`)
-		},
+		async () => k.render(undefined, '/base/'),
 		{message: /callback_data only supports 1-64 bytes/},
 	)
 })

--- a/source/keyboard.test.ts
+++ b/source/keyboard.test.ts
@@ -144,7 +144,7 @@ test('hints too long cyrillic callback data', async t => {
 	const relativePath = 'очень длинный абсолютный путь больше 32 символов'
 
 	const k = new Keyboard<unknown>()
-	k.add(false, {text: 'bla', relativePath})
+	k.add(false, {text: 'bla', relativePath: `/${relativePath}/`})
 
 	await t.throwsAsync(
 		async () => {

--- a/source/keyboard.test.ts
+++ b/source/keyboard.test.ts
@@ -139,3 +139,17 @@ test('hints too long callback data', async t => {
 		{message: /callback_data only supports 1-64 bytes/},
 	)
 })
+
+test('hints too long cyrillic callback data', async t => {
+	const relativePath = 'очень длинный абсолютный путь больше 32 символов'
+
+	const k = new Keyboard<unknown>()
+	k.add(false, {text: 'bla', relativePath})
+
+	await t.throwsAsync(
+		async () => {
+			await k.render(undefined, `/${relativePath}/`)
+		},
+		{message: /callback_data only supports 1-64 bytes/},
+	)
+})

--- a/source/keyboard.ts
+++ b/source/keyboard.ts
@@ -78,8 +78,9 @@ function renderRow(templates: readonly ButtonTemplate[], path: string): readonly
 
 function renderCallbackButtonTemplate(template: CallbackButtonTemplate, path: string): InlineKeyboardButton {
 	const absolutePath = combinePath(path, template.relativePath)
-	if (absolutePath.length > 64) {
-		throw new Error(`callback_data only supports 1-64 bytes. With this button (${template.relativePath}) it would get too long (${absolutePath.length}). Full path: ${absolutePath}`)
+	const absolutePathLength = Buffer.byteLength(absolutePath, 'utf-8')
+	if (absolutePathLength > 64) {
+		throw new Error(`callback_data only supports 1-64 bytes. With this button (${template.relativePath}) it would get too long (${absolutePathLength}). Full path: ${absolutePath}`)
 	}
 
 	return {

--- a/source/keyboard.ts
+++ b/source/keyboard.ts
@@ -1,3 +1,5 @@
+import {Buffer} from 'node:buffer'
+
 import {InlineKeyboardButton as TelegramInlineKeyboardButton} from '@grammyjs/types'
 import {ReadonlyDeep} from 'type-fest'
 
@@ -78,7 +80,7 @@ function renderRow(templates: readonly ButtonTemplate[], path: string): readonly
 
 function renderCallbackButtonTemplate(template: CallbackButtonTemplate, path: string): InlineKeyboardButton {
 	const absolutePath = combinePath(path, template.relativePath)
-	const absolutePathLength = Buffer.byteLength(absolutePath, 'utf-8')
+	const absolutePathLength = Buffer.byteLength(absolutePath, 'utf8')
 	if (absolutePathLength > 64) {
 		throw new Error(`callback_data only supports 1-64 bytes. With this button (${template.relativePath}) it would get too long (${absolutePathLength}). Full path: ${absolutePath}`)
 	}


### PR DESCRIPTION
Fix calculating button absolute path length with non-Latin symbols according issue https://github.com/EdJoPaTo/grammy-inline-menu/issues/183