### PR TITLE
docs(jsdoc): correct submenu function args order

### DIFF
--- a/source/menu-template.ts
+++ b/source/menu-template.ts
@@ -268,7 +268,7 @@ export class MenuTemplate<Context> {
 	 * })
 	 * submenuTemplate.manualRow(createBackMainMenuButtons())
 	 *
-	 * menuTemplate.submenu('unique', submenuTemplate, { text: 'Text' })
+	 * menuTemplate.submenu('unique', submenuTemplate, { text: 'enter submenu' })
 	 */
 	submenu(
 		uniqueIdentifier: string,

--- a/source/menu-template.ts
+++ b/source/menu-template.ts
@@ -268,7 +268,7 @@ export class MenuTemplate<Context> {
 	 * })
 	 * submenuTemplate.manualRow(createBackMainMenuButtons())
 	 *
-	 * menuTemplate.submenu('enter submenu', 'unique', submenuTemplate)
+	 * menuTemplate.submenu('unique', submenuTemplate, { text: 'Text' })
 	 */
 	submenu(
 		uniqueIdentifier: string,


### PR DESCRIPTION
After updating to version 9, the text of the buttons moved to options, while the documentation for submenu retained the previous implementation