### PR TITLE
feat(body): add entities formatting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ const menuTemplate = new MenuTemplate<MyContext>((ctx) => {
 });
 ```
 
-### Can I use `entities` like with `grammyjs/parse-mode` in the message body?
+### Can I use `entities` in the message body?
 
-Yes, you can pass the option `entities`.
+Also see: [`grammyjs/parse-mode`](https://github.com/grammyjs/parse-mode)
 
 ```ts
 import { bold, fmt, underline } from '@grammyjs/parse-mode';
 
 const menu = new MenuTemplate<MyContext>(async () => {
-	const message = fmt`${bold(underline('Hello world!'))}`
+	const message = fmt`${bold(underline('Hello world!'))}`;
 	return {
 		text: message.text,
 		entities: message.entities,

--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ const menuTemplate = new MenuTemplate<MyContext>((ctx) => {
 });
 ```
 
+### Can I use entities or `grammyjs/parse-mode` in the message body?
+
+Yes, you can pass the option `entities`.
+
+This will be resolved automatically to`caption_entities` if you send a `media` message.
+
+```ts
+const menu = new MenuTemplate<MyContext>(async () => {
+	const message = fmt`${bold(underline('Hello world!'))}`
+
+	return {
+		text: message.text,
+		entities: message.entities,
+	};
+});
+```
+
 ### Can the menu body be some media?
 
 The menu body can be an object containing `media` and `type` for media.

--- a/README.md
+++ b/README.md
@@ -160,16 +160,15 @@ const menuTemplate = new MenuTemplate<MyContext>((ctx) => {
 });
 ```
 
-### Can I use entities or `grammyjs/parse-mode` in the message body?
+### Can I use `entities` like with `grammyjs/parse-mode` in the message body?
 
 Yes, you can pass the option `entities`.
 
-This will be resolved automatically to`caption_entities` if you send a `media` message.
-
 ```ts
+import { bold, fmt, underline } from '@grammyjs/parse-mode';
+
 const menu = new MenuTemplate<MyContext>(async () => {
 	const message = fmt`${bold(underline('Hello world!'))}`
-
 	return {
 		text: message.text,
 		entities: message.entities,

--- a/source/body.test.ts
+++ b/source/body.test.ts
@@ -112,6 +112,21 @@ const EXAMPLE_TEXTS: ReadonlyArray<string | TextBody> = [
 		text: 'Hello World',
 		disable_web_page_preview: true,
 	},
+	{
+		text: 'Hello world!',
+		entities: [
+			{
+				type: 'bold',
+				offset: 0,
+				length: 5,
+			},
+			{
+				type: 'italic',
+				offset: 6,
+				length: 5,
+			},
+		],
+	},
 ];
 
 const EXAMPLE_MEDIA: readonly MediaBody[] = [
@@ -129,6 +144,23 @@ const EXAMPLE_MEDIA: readonly MediaBody[] = [
 		type: 'photo',
 		text: 'whatever',
 		parse_mode: 'Markdown',
+	},
+	{
+		media: 'whatever',
+		type: 'photo',
+		text: 'Hello world!',
+		entities: [
+			{
+				type: 'bold',
+				offset: 0,
+				length: 5,
+			},
+			{
+				type: 'italic',
+				offset: 6,
+				length: 5,
+			},
+		],
 	},
 ];
 

--- a/source/body.ts
+++ b/source/body.ts
@@ -1,6 +1,6 @@
 import type {InputFile} from 'grammy';
 import type {
-	LabeledPrice, Location, ParseMode, Venue,
+	LabeledPrice, Location, MessageEntity, ParseMode, Venue,
 } from 'grammy/types';
 import type {ReadonlyDeep} from 'type-fest';
 import {hasTruthyKey, isObject} from './generic-types.js';
@@ -24,6 +24,7 @@ export type MediaType = typeof MEDIA_TYPES[number];
 
 export type TextBody = {
 	readonly text: string;
+	readonly entities?: MessageEntity[];
 	readonly parse_mode?: ParseMode;
 	readonly disable_web_page_preview?: boolean;
 };
@@ -34,6 +35,7 @@ export type MediaBody = {
 
 	/** Caption */
 	readonly text?: string;
+	readonly entities?: MessageEntity[];
 	readonly parse_mode?: ParseMode;
 };
 

--- a/source/body.ts
+++ b/source/body.ts
@@ -162,6 +162,7 @@ export function isInvoiceBody(body: unknown): body is InvoiceBody {
 		&& typeof invoice.description === 'string';
 }
 
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 export function getBodyText(body: TextBody | string): string {
 	return typeof body === 'string' ? body : body.text;
 }

--- a/source/send-menu.ts
+++ b/source/send-menu.ts
@@ -361,6 +361,7 @@ export function generateEditMessageIntoMenuFunction<Context>(
 					type: body.type,
 					media: body.media,
 					caption: body.text,
+					caption_entities: body.entities,
 					parse_mode: body.parse_mode,
 				},
 				createGenericOther(keyboard, other),
@@ -407,6 +408,7 @@ function createTextOther(
 ) {
 	return {
 		...base,
+		entities: typeof body === 'string' ? undefined : body.entities,
 		parse_mode: typeof body === 'string' ? undefined : body.parse_mode,
 		disable_web_page_preview: typeof body !== 'string'
 			&& body.disable_web_page_preview,
@@ -426,6 +428,7 @@ function createSendMediaOther(
 		...base,
 		parse_mode: body.parse_mode,
 		caption: body.text,
+		caption_entities: body.entities,
 		reply_markup: {
 			inline_keyboard: keyboard.map(o => [...o]),
 		},

--- a/source/send-menu.ts
+++ b/source/send-menu.ts
@@ -402,6 +402,7 @@ export function generateEditMessageIntoMenuFunction<Context>(
 }
 
 function createTextOther(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	body: string | TextBody,
 	keyboard: InlineKeyboard,
 	base: Readonly<Record<string, unknown>>,

--- a/test/menu-middleware/reply-to-context.ts
+++ b/test/menu-middleware/reply-to-context.ts
@@ -29,6 +29,7 @@ await test('menu-middleware reply-to-context replies main menu', async t => {
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -67,6 +68,7 @@ await test('menu-middleware reply-to-context replies main menu explicitly', asyn
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -105,6 +107,7 @@ await test('menu-middleware reply-to-context replies submenu', async t => {
 		strictEqual(text, 'submenu');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],

--- a/test/send-menu/context-edit.ts
+++ b/test/send-menu/context-edit.ts
@@ -13,6 +13,7 @@ await test('context-edit text reply when not a callback query', async t => {
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -36,6 +37,7 @@ await test('context-edit text reply when no message on callback query', async t 
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -65,6 +67,7 @@ await test('context-edit text edit when message is a text message', async t => {
 			strictEqual(text, 'whatever');
 			deepStrictEqual(other, {
 				disable_web_page_preview: false,
+				entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -106,6 +109,7 @@ await test('context-edit text reply when message is a media message', async t =>
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -151,6 +155,7 @@ await test('context-edit text reply when message is a media message but fails wi
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -193,6 +198,7 @@ await test('context-edit media reply when not a callback query', async t => {
 			strictEqual(photo, 'whatever');
 			deepStrictEqual(other, {
 				caption: undefined,
+				caption_entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -227,6 +233,7 @@ await test('context-edit media reply when text message', async t => {
 			strictEqual(photo, 'whatever');
 			deepStrictEqual(other, {
 				caption: undefined,
+				caption_entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -375,6 +382,7 @@ await test('context-edit text edit without webpage preview', async () => {
 		async editMessageText(_text, other) {
 			deepStrictEqual(other, {
 				disable_web_page_preview: true,
+				entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -409,6 +417,7 @@ await test('context-edit text edit with parse mode', async () => {
 		async editMessageText(_text, other) {
 			deepStrictEqual(other, {
 				disable_web_page_preview: undefined,
+				entities: undefined,
 				parse_mode: 'Markdown',
 				reply_markup: {
 					inline_keyboard: [],

--- a/test/send-menu/context-reply.ts
+++ b/test/send-menu/context-reply.ts
@@ -19,6 +19,7 @@ await test('context-reply media', async t => {
 						strictEqual(media, 'whatever');
 						deepStrictEqual(other, {
 							caption: undefined,
+							caption_entities: undefined,
 							parse_mode: undefined,
 							reply_markup: {
 								inline_keyboard: [],

--- a/test/send-menu/context-resend.ts
+++ b/test/send-menu/context-resend.ts
@@ -15,6 +15,7 @@ await test('context-resend on callback query', async t => {
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],
@@ -52,6 +53,7 @@ await test('context-resend on whatever', async t => {
 		strictEqual(text, 'whatever');
 		deepStrictEqual(other, {
 			disable_web_page_preview: false,
+			entities: undefined,
 			parse_mode: undefined,
 			reply_markup: {
 				inline_keyboard: [],

--- a/test/send-menu/telegram-edit.ts
+++ b/test/send-menu/telegram-edit.ts
@@ -15,6 +15,7 @@ await test('telegram-edit text', async () => {
 			strictEqual(text, 'whatever');
 			deepStrictEqual(other, {
 				disable_web_page_preview: false,
+				entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -59,6 +60,7 @@ await test('telegram-edit media', async t => {
 							media: 'whatever',
 							type: mediaType,
 							caption: undefined,
+							caption_entities: undefined,
 							parse_mode: undefined,
 						});
 						deepStrictEqual(other, {

--- a/test/send-menu/telegram-send.ts
+++ b/test/send-menu/telegram-send.ts
@@ -14,6 +14,7 @@ await test('telegram-send text', async () => {
 			strictEqual(text, 'whatever');
 			deepStrictEqual(other, {
 				disable_web_page_preview: false,
+				entities: undefined,
 				parse_mode: undefined,
 				reply_markup: {
 					inline_keyboard: [],
@@ -59,6 +60,7 @@ await test('telegram-send media', async t => {
 					strictEqual(media, 'whatever');
 					deepStrictEqual(other, {
 						caption: undefined,
+						caption_entities: undefined,
 						parse_mode: undefined,
 						reply_markup: {
 							inline_keyboard: [],

--- a/test/send-menu/telegram-send.ts
+++ b/test/send-menu/telegram-send.ts
@@ -235,3 +235,65 @@ await test('telegram-send invoice', async () => {
 
 	await sendMenu(666, fakeContext as any);
 });
+
+await test('telegram-send text with entities', async () => {
+	const menu = new MenuTemplate<BaseContext>({
+		text: 'Hello world!',
+		entities: [
+			{
+				type: 'bold',
+				offset: 0,
+				length: 5,
+			},
+			{
+				type: 'italic',
+				offset: 6,
+				length: 5,
+			},
+		],
+	});
+
+	const fakeTelegram: Partial<Api> = {
+		async sendMessage(chatId, text, other) {
+			strictEqual(chatId, 666);
+			strictEqual(text, 'Hello world!');
+			deepStrictEqual(other, {
+				disable_web_page_preview: undefined,
+				entities: [
+					{
+						type: 'bold',
+						offset: 0,
+						length: 5,
+					},
+					{
+						type: 'italic',
+						offset: 6,
+						length: 5,
+					},
+				],
+				parse_mode: undefined,
+				reply_markup: {
+					inline_keyboard: [],
+				},
+			});
+			return {} as any;
+		},
+	};
+
+	const sendMenu = generateSendMenuToChatFunction(
+		fakeTelegram as any,
+		menu,
+		'/',
+	);
+
+	const fakeContext: Partial<BaseContext> = {
+		callbackQuery: {
+			id: '666',
+			from: undefined as any,
+			chat_instance: '666',
+			data: '666',
+		},
+	};
+
+	await sendMenu(666, fakeContext as any);
+});


### PR DESCRIPTION
Hi !

This pull request adds the support to entities on text messages sent.
This allows:
- messages to be formatted with this Telegram method, instead of Markdown or HTML,
- the usage of `FormattedString` objects created with [grammyjs/parse-mode](https://github.com/grammyjs/parse-mode).

### Example

```ts
import { bold, fmt, underline } from '@grammyjs/parse-mode';
import { MenuTemplate } from 'grammy-inline-menu';

const menu = new MenuTemplate<MyContext>(async () => {
    const message = fmt`${bold(underline('Hello world!'))}`

    return {
        text: message.text,
        entities: message.entities,
    };
});
```